### PR TITLE
Fix cli-scan.php for calls from other working directories

### DIFF
--- a/example/cli-scan.php
+++ b/example/cli-scan.php
@@ -14,7 +14,7 @@ class RIPSExample
     {
         $curl = array(
             // Only required for CURL on Windows.
-            CURLOPT_CAINFO => 'ca.crt'
+            CURLOPT_CAINFO => __DIR__ . '/ca.crt'
         );
 
         $this->rips = new Client(false, $curl);


### PR DESCRIPTION
When a user wants to call the `cli-scan.php` script from another working directory as the one `cli-scan.php` and `ca.crt` lies in, the script isn't able to find its cert.