### PR TITLE
More useful error messages

### DIFF
--- a/example/cli-scan.php
+++ b/example/cli-scan.php
@@ -97,10 +97,10 @@ if ($argc < 4) {
 try {
     $example = new RIPSExample($argv[1], $argv[2]);
 } catch (NotAuthorizedError $e) {
-    echo "Invalid login\n";
+    echo "Invalid login. Reason: ". $e->getMessage() . "\n";
     exit(1);
 } catch (Exception $e) {
-    echo "Could not connect\n";
+    echo "Could not connect. Reason: ". $e->getMessage()."\n";
     exit(1);
 }
 


### PR DESCRIPTION
In PR #4 the error message for not finding the `ca.crt` was

> Could to connect

After this PR got merged it will be

> Could not connect. Reason: SSL: can't load CA certificate file ca.crt

Which is heaps more useful as the status quo.